### PR TITLE
Add API wrapper for tasks

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,1 +1,2 @@
-export * from "./products/products";
+export * from "./products";
+export * from "./tasks";

--- a/src/api/tasks/index.ts
+++ b/src/api/tasks/index.ts
@@ -1,0 +1,2 @@
+export * from "./tasks";
+export * from "./types";

--- a/src/api/tasks/tasks.ts
+++ b/src/api/tasks/tasks.ts
@@ -1,0 +1,46 @@
+import { ApiInstance } from "@/hooks/useApiInstance";
+import { Task, TaskDTO, TaskCreateDTO, TaskUpdateDTO } from "./types";
+
+// Test API
+// https://euricom-test-api-v2.herokuapp.com/docs
+// https://euricom-test-api-v2.herokuapp.com/openapi
+
+const taskMapper = (dto: TaskDTO): Task => ({ ...dto });
+
+export const getTask = async (
+  api: ApiInstance,
+  id: string
+): Promise<Task> => {
+  const data = await api.get<TaskDTO>(`/api/v1/tasks/${id}`);
+  return taskMapper(data);
+};
+
+export const getTasks = async (api: ApiInstance): Promise<Task[]> => {
+  const data = await api.get<TaskDTO[]>("/api/v1/tasks");
+  return data.map(taskMapper);
+};
+
+export const createTask = async (
+  api: ApiInstance,
+  task: TaskCreateDTO
+): Promise<Task> => {
+  const data = await api.post<TaskDTO>("/api/v1/tasks", task);
+  return taskMapper(data);
+};
+
+export const updateTask = async (
+  api: ApiInstance,
+  id: string,
+  task: TaskUpdateDTO
+): Promise<Task> => {
+  const data = await api.put<TaskDTO>(`/api/v1/tasks/${id}`, task);
+  return taskMapper(data);
+};
+
+export const deleteTask = async (
+  api: ApiInstance,
+  id: string
+): Promise<Task> => {
+  const data = await api.delete<TaskDTO>(`/api/v1/tasks/${id}`);
+  return taskMapper(data);
+};

--- a/src/api/tasks/types.ts
+++ b/src/api/tasks/types.ts
@@ -1,0 +1,7 @@
+import { components } from "../schema";
+
+export type TaskDTO = components["schemas"]["task"];
+export type TaskCreateDTO = components["schemas"]["taskCreate"];
+export type TaskUpdateDTO = components["schemas"]["taskUpdate"];
+
+export type Task = TaskDTO;


### PR DESCRIPTION
## Summary
- add API wrapper for tasks
- export tasks utilities from api index

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_683f0b644f84833292bda37e53350828